### PR TITLE
Support compilation on stable Rust channels

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! FFI bindings and Rust wrappers for [libfswatch](https://github.com/emcrisostomo/fswatch).
 
-#![feature(unique)]
-#![feature(const_fn)]
 #![allow(non_camel_case_types)]
 
 pub extern crate fswatch_sys;


### PR DESCRIPTION
Related to https://github.com/jkcclemens/fswatch-sys/pull/1 :) this appears to be all that is required to support stable - I can't test due to not having fswatch to compile but I'm relying on Travis doing it for me.